### PR TITLE
Refactor noise module (2/3): Update standard_errors

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -413,7 +413,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
             name = inst.label if isinstance(inst, UnitaryGate) and inst.label else inst.name
             dic = {'name': name,
                    'qubits': [bit_indices[q] for q in qargs]}
-            if name in {'kraus', 'unitary'}:
+            if name in {'kraus', 'unitary', 'pauli'}:
                 dic['params'] = inst.params
             ret.append(dic)
         return ret

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -407,11 +407,12 @@ class QuantumError(BaseOperator, TolerancesMixin):
 
     @staticmethod
     def _qc_to_json(qc: QuantumCircuit):
+        bit_indices = {bit: index for index, bit in enumerate(qc.qubits)}
         ret = []
         for inst, qargs, _ in qc:
             name = inst.label if isinstance(inst, UnitaryGate) and inst.label else inst.name
             dic = {'name': name,
-                   'qubits': [q.index for q in qargs]}
+                   'qubits': [bit_indices[q] for q in qargs]}
             if name in {'kraus', 'unitary'}:
                 dic['params'] = inst.params
             ret.append(dic)

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -109,7 +109,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
             QuantumError.atol = atol
             warnings.warn(
                 '"atol" option in the constructor of QuantumError has been deprecated'
-                ' as of qiskit-aer 0.8.0 and will be removed no earlier than 3 months'
+                ' as of qiskit-aer 0.10.0 and will be removed no earlier than 3 months'
                 ' from that release date. Use QuantumError.atol = value',
                 DeprecationWarning, stacklevel=2)
 
@@ -118,7 +118,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
                 len(noise_ops) > 0 and isinstance(noise_ops[0], np.ndarray):
             warnings.warn(
                 'Constructing QuantumError with list of arrays representing a Kraus channel'
-                ' has been deprecated as of qiskit-aer 0.8.0 and will be removed no earlier than'
+                ' has been deprecated as of qiskit-aer 0.10.0 and will be removed no earlier than'
                 ' 3 months from that release date. Use QuantumError(Kraus()) instead.',
                 DeprecationWarning, stacklevel=2)
             if standard_gates:
@@ -163,7 +163,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
             ops = [standard_gates_instructions(op) for op in ops]
             warnings.warn(
                 '"standard_gates" option in the constructor of QuantumError has been deprecated'
-                ' as of qiskit-aer 0.8.0 in favor of externalizing such an unrolling functionality'
+                ' as of qiskit-aer 0.10.0 in favor of externalizing such an unrolling functionality'
                 ' and will be removed no earlier than 3 months from that release date.',
                 DeprecationWarning, stacklevel=2)
 
@@ -182,7 +182,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
             num_qubits = number_of_qubits
             warnings.warn(
                 '"number_of_qubits" in the constructor of QuantumError has been deprecated'
-                ' as of qiskit-aer 0.8.0 in favor of determining it automatically'
+                ' as of qiskit-aer 0.10.0 in favor of determining it automatically'
                 ' and will be removed no earlier than 3 months from that release date.'
                 ' Specify number of qubits in the quantum circuit passed to the init if necessary.',
                 DeprecationWarning, stacklevel=2)
@@ -243,7 +243,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
             elif all(isinstance(aop, dict) for aop in op):
                 warnings.warn(
                     'Constructing QuantumError with list of dict representing a mixed channel'
-                    ' has been deprecated as of qiskit-aer 0.8.0 and will be removed'
+                    ' has been deprecated as of qiskit-aer 0.10.0 and will be removed'
                     ' no earlier than 3 months from that release date.',
                     DeprecationWarning, stacklevel=3)
                 # Convert json-like to non-kraus Instruction
@@ -303,7 +303,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
     def set_atol(cls, value):
         """Set the class default absolute tolerance parameter for float comparisons."""
         warnings.warn(
-            'QuantumError.set_atol(value) has been deprecated as of qiskit-aer 0.8.0'
+            'QuantumError.set_atol(value) has been deprecated as of qiskit-aer 0.10.0'
             ' and will be removed no earlier than 3 months from that release date.'
             ' Use QuantumError.atol = value instead.',
             DeprecationWarning, stacklevel=2)
@@ -313,7 +313,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
     def set_rtol(cls, value):
         """Set the class default relative tolerance parameter for float comparisons."""
         warnings.warn(
-            'QuantumError.set_rtol(value) has been deprecated as of qiskit-aer 0.8.0'
+            'QuantumError.set_rtol(value) has been deprecated as of qiskit-aer 0.10.0'
             ' and will be removed no earlier than 3 months from that release date.'
             ' Use QuantumError.rtol = value instead.',
             DeprecationWarning, stacklevel=2)
@@ -329,7 +329,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
         """Return the number of qubits for the error."""
         warnings.warn(
             '"number_of_qubits" property has been renamed to num_qubits and deprecated as of'
-            ' qiskit-aer 0.8.0, and will be removed no earlier than 3 months'
+            ' qiskit-aer 0.10.0, and will be removed no earlier than 3 months'
             ' from that release date. Use "num_qubits" instead.',
             DeprecationWarning, stacklevel=2)
         return self.num_qubits

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -165,7 +165,6 @@ def pauli_error(noise_ops, standard_gates=True):
     Raises:
         NoiseError: If depolarizing probability is less than 0 or greater than 1.
     """
-    # TODO: Can we deprecate this function itself?
     # Error checking
     if not isinstance(noise_ops, (list, tuple, zip)):
         raise NoiseError("Input noise ops is not a list.")

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -55,7 +55,7 @@ def kraus_error(noise_ops, standard_gates=False, canonical_kraus=False):
 
     if standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.9.0'
             ' and will be removed no earlier than 3 months from that release date.',
             DeprecationWarning, stacklevel=2)
 
@@ -86,7 +86,7 @@ def mixed_unitary_error(noise_ops, standard_gates=False):
     """
     if standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.9.0'
             ' and will be removed no earlier than 3 months from that release date.'
             ' Use directly init e.g. QuantumError([(IGate(), prob1), (ZGate(), prob2)]) instead.',
             DeprecationWarning, stacklevel=2)
@@ -198,7 +198,7 @@ def pauli_error(noise_ops, standard_gates=True):
 
     if not standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.9.0'
             ' and will be removed no earlier than 3 months from that release date.',
             DeprecationWarning, stacklevel=2)
         paulis = [UnitaryGate(pauli.to_matrix()) for pauli in paulis]
@@ -243,7 +243,7 @@ def depolarizing_error(param, num_qubits, standard_gates=True):
     """
     if not standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.9.0'
             ' and will be removed no earlier than 3 months from that release date.',
             DeprecationWarning, stacklevel=2)
 

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -54,7 +54,7 @@ def kraus_error(noise_ops, standard_gates=False, canonical_kraus=False):
 
     if standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.8.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
             ' and will be removed no earlier than 3 months from that release date.',
             DeprecationWarning, stacklevel=2)
 
@@ -85,7 +85,7 @@ def mixed_unitary_error(noise_ops, standard_gates=False):
     """
     if standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.8.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
             ' and will be removed no earlier than 3 months from that release date.'
             ' Use directly init e.g. QuantumError([(IGate(), prob1), (ZGate(), prob2)]) instead.',
             DeprecationWarning, stacklevel=2)
@@ -197,7 +197,7 @@ def pauli_error(noise_ops, standard_gates=True):
 
     if not standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.8.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
             ' and will be removed no earlier than 3 months from that release date.',
             DeprecationWarning, stacklevel=2)
         paulis = [UnitaryGate(pauli.to_matrix()) for pauli in paulis]
@@ -242,7 +242,7 @@ def depolarizing_error(param, num_qubits, standard_gates=True):
     """
     if not standard_gates:
         warnings.warn(
-            '"standard_gates" option has been deprecated as of qiskit-aer 0.8.0'
+            '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
             ' and will be removed no earlier than 3 months from that release date.',
             DeprecationWarning, stacklevel=2)
 

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -19,6 +19,7 @@ import warnings
 import numpy as np
 from qiskit.circuit import QuantumCircuit, Reset
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
+from qiskit.exceptions import QiskitError
 from qiskit.extensions import UnitaryGate
 from qiskit.quantum_info.operators.channel import Choi, Kraus
 from qiskit.quantum_info.operators.pauli import Pauli
@@ -180,7 +181,7 @@ def pauli_error(noise_ops, standard_gates=True):
         elif isinstance(op, str):
             try:
                 return Pauli(op)
-            except AttributeError:  # TODO: Change to QiskitError after fixing Pauli._from_label
+            except QiskitError:
                 pass
         raise NoiseError("Invalid Pauli input operator: {}".format(op))
 

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -426,7 +426,7 @@ class NoiseModel:
                                 'kraus', 'superop', 'roerror']:
                     self._basis_gates.add(name)
             elif warnings:
-                warn('"warnings" option has been deprecated as of qiskit-aer 0.8.0'
+                warn('"warnings" option has been deprecated as of qiskit-aer 0.10.0'
                      ' and will be removed no earlier than 3 months from that release date.',
                      DeprecationWarning, stacklevel=2)
                 logger.warning(

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -50,6 +50,7 @@ class QiskitAerTestCase(QiskitTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.moduleName = os.path.splitext(inspect.getfile(cls))[0]
         cls.log = logging.getLogger(cls.__name__)
 

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 201, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,15 +15,20 @@ NoiseModel class integration tests
 """
 
 import unittest
-from test.terra import common
+
+import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler import assemble, transpile
+from qiskit.quantum_info.operators.pauli import Pauli
+
 from qiskit.providers.aer.backends import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
+from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
+from qiskit.providers.aer.noise.errors.standard_errors import kraus_error
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.providers.aer.noise.errors.standard_errors import reset_error
-from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
 from qiskit.test import mock
+from test.terra import common
 
 # Backwards compatibility for Terra <= 0.13
 if not hasattr(QuantumCircuit, 'i'):
@@ -161,8 +166,8 @@ class TestNoise(common.QiskitAerTestCase):
     def test_noise_models_equal(self):
         """Test two noise models are Equal"""
         roerror = [[0.9, 0.1], [0.5, 0.5]]
-        error1 = pauli_error([['X', 1]], standard_gates=False)
-        error2 = pauli_error([['X', 1]], standard_gates=True)
+        error1 = kraus_error([np.diag([1, 0]), np.diag([0, 1])])
+        error2 = pauli_error([("I", 0.5), ("Z", 0.5)])
 
         model1 = NoiseModel()
         model1.add_all_qubit_quantum_error(error1, ['u3'], False)

--- a/test/terra/noise/test_standard_errors.py
+++ b/test/terra/noise/test_standard_errors.py
@@ -85,7 +85,7 @@ class TestNoise(common.QiskitAerTestCase):
         unitary = np.diag([1, -1, 1, -1])
         error = coherent_unitary_error(unitary)
         ref = mixed_unitary_error([(unitary, 1)])
-        self.assertEqual(error.to_dict(), ref.to_dict())
+        self.assertEqual(error, ref)
 
     def test_pauli_error_raise_invalid(self):
         """Test exception for invalid Pauli string"""

--- a/test/terra/noise/test_standard_errors.py
+++ b/test/terra/noise/test_standard_errors.py
@@ -156,9 +156,9 @@ class TestNoise(common.QiskitAerTestCase):
         probs = [0.5, 0.3, 0.2]
         error = pauli_error(zip(paulis, probs))
 
-        target_circs = [[{"name": "x", "qubits": [1]}],
-                        [{"name": "y", "qubits": [1]}],
-                        [{"name": "z", "qubits": [1]}]]
+        target_circs = [[{"name": "id", "qubits": [0]}, {"name": "x", "qubits": [1]}],
+                        [{"name": "id", "qubits": [0]}, {"name": "y", "qubits": [1]}],
+                        [{"name": "id", "qubits": [0]}, {"name": "z", "qubits": [1]}]]
         target_probs = probs.copy()
 
         for j in range(len(paulis)):
@@ -225,13 +225,13 @@ class TestNoise(common.QiskitAerTestCase):
         """Test 2-qubit depolarizing error as gate qobj"""
         p_depol = 0.3
         error = depolarizing_error(p_depol, 2, standard_gates=True)
-        target_circs = [[{"name": "id", "qubits": [0]}],
-                        [{"name": "x", "qubits": [0]}],
-                        [{"name": "y", "qubits": [0]}],
-                        [{"name": "z", "qubits": [0]}],
-                        [{"name": "x", "qubits": [1]}],
-                        [{"name": "y", "qubits": [1]}],
-                        [{"name": "z", "qubits": [1]}],
+        target_circs = [[{"name": "id", "qubits": [0]}, {"name": "id", "qubits": [1]}],
+                        [{"name": "x", "qubits": [0]}, {"name": "id", "qubits": [1]}],
+                        [{"name": "y", "qubits": [0]}, {"name": "id", "qubits": [1]}],
+                        [{"name": "z", "qubits": [0]}, {"name": "id", "qubits": [1]}],
+                        [{"name": "id", "qubits": [0]}, {"name": "x", "qubits": [1]}],
+                        [{"name": "id", "qubits": [0]}, {"name": "y", "qubits": [1]}],
+                        [{"name": "id", "qubits": [0]}, {"name": "z", "qubits": [1]}],
                         [{"name": "x", "qubits": [0]}, {"name": "x", "qubits": [1]}],
                         [{"name": "x", "qubits": [0]}, {"name": "y", "qubits": [1]}],
                         [{"name": "x", "qubits": [0]}, {"name": "z", "qubits": [1]}],
@@ -245,7 +245,7 @@ class TestNoise(common.QiskitAerTestCase):
             circ, p = error.error_term(j)
             circ = QuantumError._qc_to_json(circ)
             self.remove_if_found(circ, target_circs)
-            if circ == [{"name": "id", "qubits": [0]}]:
+            if circ == [{"name": "id", "qubits": [0]}, {"name": "id", "qubits": [1]}]:
                 self.assertAlmostEqual(p, 1 - p_depol + p_depol / 16,
                                        msg="Incorrect identity probability")
             else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is the second PR, which mainly updates standard_errors, for the noise module refactoring (planned to be composed of three PRs).

The refactoring aims to update noise module to use QuantumCircuit internally instead of qobj (json). That will make it easy for users to customize their noise models and enable developers to leverage their familiar circuit module for future enhancement of noise module.

1st PR: Update QuantumError (& NoiseModel (minor changes))
2th PR: Update standard_errors <== This PR
3rd PR: Update noise.utils


### Details and comments
- Deprecate `standard_gates` option for all `standard_errors` functions
- Update implementation of `standard_errors` functions so that each of them creates a QuantumError object using the new API introduced in the 1st PR
