### PR TITLE
Refactor noise module (3/3): Update utility functions

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -122,8 +122,10 @@ class QuantumError(BaseOperator, TolerancesMixin):
                 ' 3 months from that release date. Use QuantumError(Kraus()) instead.',
                 DeprecationWarning, stacklevel=2)
             if standard_gates:
-                noise_ops = kraus2instructions(
-                    noise_ops, standard_gates, atol=self.atol)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    noise_ops = kraus2instructions(
+                        noise_ops, standard_gates, atol=self.atol)
             else:
                 try:
                     noise_ops = Kraus(noise_ops)
@@ -160,7 +162,9 @@ class QuantumError(BaseOperator, TolerancesMixin):
         ops, probs = zip(*noise_ops)  # unzip
 
         if standard_gates:
-            ops = [standard_gates_instructions(op) for op in ops]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ops = [standard_gates_instructions(op) for op in ops]
             warnings.warn(
                 '"standard_gates" option in the constructor of QuantumError has been deprecated'
                 ' as of qiskit-aer 0.9.0 in favor of externalizing such an unrolling functionality'
@@ -264,9 +268,11 @@ class QuantumError(BaseOperator, TolerancesMixin):
                         circ.append(UnitaryGate(data=dic['params'][0]),
                                     qargs=dic['qubits'])
                     else:
-                        circ.append(UnitaryGate(label=dic['name'],
-                                                data=standard_gate_unitary(dic['name'])),
-                                    qargs=dic['qubits'])
+                        with warnings.catch_warnings():
+                            warnings.simplefilter("ignore")
+                            circ.append(UnitaryGate(label=dic['name'],
+                                                    data=standard_gate_unitary(dic['name'])),
+                                        qargs=dic['qubits'])
                 return circ
             else:
                 raise NoiseError("Invalid type of op list: {}".format(op))

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -116,8 +116,10 @@ def mixed_unitary_error(noise_ops, standard_gates=False):
         else:
             if standard_gates:  # TODO: to be removed after deprecation period
                 qubits = list(range(num_qubits))
-                instr = make_unitary_instruction(
-                    unitary, qubits, standard_gates=standard_gates)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    instr = make_unitary_instruction(
+                        unitary, qubits, standard_gates=standard_gates)
             else:
                 instr = UnitaryGate(unitary)
             instructions.append(instr)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is the second PR, which mainly updates standard_errors, for the noise module refactoring (planned to be composed of three PRs).

The refactoring aims to update noise module to use QuantumCircuit internally instead of qobj (json). That will make it easy for users to customize their noise models and enable developers to leverage their familiar circuit module for future enhancement of noise module.

1st PR: Update QuantumError (& NoiseModel (minor changes))
2th PR: Update standard_errors
3rd PR: Update noise.utils <== This PR

### Details and comments

- Deprecate all functions in `noise.errors.errorutils`
- TBD

